### PR TITLE
fix: log display

### DIFF
--- a/momo/files/momo.init
+++ b/momo/files/momo.init
@@ -180,7 +180,7 @@ start_service() {
 	log "Core" "Start."
 	procd_open_instance momo
 
-	procd_set_param command /bin/sh -c "$PROG -D $RUN_DIR run >> $CORE_LOG_PATH 2>&1"
+	procd_set_param command /bin/sh -c "$PROG -D $RUN_DIR run --disable-color >> $CORE_LOG_PATH 2>&1"
 	procd_set_param file "$RUN_PROFILE_PATH"
 	if [ "$fast_reload" = 1 ]; then
 		procd_set_param reload_signal HUP


### PR DESCRIPTION
Disable color makes log more readable.

Before:
<img width="908" height="689" alt="Снимок экрана_20260131_083317" src="https://github.com/user-attachments/assets/7312886d-cdfb-4566-841f-c044fb5be9a9" />

After:
<img width="908" height="689" alt="Снимок экрана_20260131_083723" src="https://github.com/user-attachments/assets/2cb03840-80bd-4256-9561-6a67b4978fcb" />
