### PR TITLE
fix: Add 'service/sing-box' to Default Bypass 'cgroup'

### DIFF
--- a/momo/files/momo.conf
+++ b/momo/files/momo.conf
@@ -79,6 +79,7 @@ config router_access_control
 	list 'cgroup' 'services/dnsmasq'
 	list 'cgroup' 'services/netbird'
 	list 'cgroup' 'services/qbittorrent'
+	list 'cgroup' 'services/sing-box'
 	list 'cgroup' 'services/sysntpd'
 	list 'cgroup' 'services/tailscale'
 	list 'cgroup' 'services/zerotier'


### PR DESCRIPTION
This change is made in order to avoid a logical deadlock that the service fails to start when user starts the service for the first time or adds new remote ruleset file(s) with the 'proxy.enabled' option toggled, because the sing-box core can't download the remote ruleset file(s).