### PR TITLE
feat: add configurable log cleanup scheduling

### DIFF
--- a/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js
+++ b/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js
@@ -24,6 +24,34 @@ return view.extend({
 
         m = new form.Map('momo');
 
+        s = m.section(form.NamedSection, 'log', 'log', _('Log Cleanup'));
+
+        o = s.option(form.Flag, 'log_cleanup_enabled', _('Scheduled Log Cleanup'));
+        o.rmempty = false;
+
+        o = s.option(form.Value, 'log_cleanup_cron_expression', _('Log Cleanup Cron Expression'));
+        o.retain = true;
+        o.rmempty = false;
+        o.placeholder = '0 4 * * *';
+        o.depends('log_cleanup_enabled', '1');
+        o.description = _('Run unconditional log cleanup at the configured cron schedule.');
+
+        o = s.option(form.Flag, 'log_cleanup_size_enabled', _('Size-based Log Cleanup'));
+        o.rmempty = false;
+
+        o = s.option(form.Value, 'log_cleanup_size_check_cron_expression', _('Log Size Check Cron Expression'));
+        o.retain = true;
+        o.rmempty = false;
+        o.placeholder = '*/30 * * * *';
+        o.depends('log_cleanup_size_enabled', '1');
+        o.description = _('Check log size at the configured cron schedule before cleaning up.');
+
+        o = s.option(form.Value, 'log_cleanup_size_mb', _('Log Cleanup Size Threshold (MB)'));
+        o.datatype = 'uinteger';
+        o.placeholder = '50';
+        o.depends('log_cleanup_size_enabled', '1');
+        o.description = _('Clear app, core and debug logs when their total size reaches this threshold.');
+
         s = m.section(form.NamedSection, 'placeholder', 'placeholder', _('Log'));
 
         s.tab('app_log', _('App Log'));
@@ -119,8 +147,5 @@ return view.extend({
         };
 
         return m.render();
-    },
-    handleSaveApply: null,
-    handleSave: null,
-    handleReset: null
+    }
 });

--- a/luci-app-momo/po/templates/momo.pot
+++ b/luci-app-momo/po/templates/momo.pot
@@ -425,3 +425,39 @@ msgstr ""
 #: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/app.js:128
 msgid "procd Config"
 msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:47
+msgid "Check log size at the configured cron schedule before cleaning up."
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:53
+msgid "Clear app, core and debug logs when their total size reaches this threshold."
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:27
+msgid "Log Cleanup"
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:32
+msgid "Log Cleanup Cron Expression"
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:49
+msgid "Log Cleanup Size Threshold (MB)"
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:42
+msgid "Log Size Check Cron Expression"
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:37
+msgid "Run unconditional log cleanup at the configured cron schedule."
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:29
+msgid "Scheduled Log Cleanup"
+msgstr ""
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:39
+msgid "Size-based Log Cleanup"
+msgstr ""

--- a/luci-app-momo/po/zh_Hans/momo.po
+++ b/luci-app-momo/po/zh_Hans/momo.po
@@ -432,3 +432,39 @@ msgstr "用户代理（UA）"
 #: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/app.js:128
 msgid "procd Config"
 msgstr "procd 配置"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:47
+msgid "Check log size at the configured cron schedule before cleaning up."
+msgstr "按设定的 Cron 周期检查日志大小，满足条件后再清理。"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:53
+msgid "Clear app, core and debug logs when their total size reaches this threshold."
+msgstr "当插件日志、核心日志和调试日志总大小达到该阈值时自动清理。"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:27
+msgid "Log Cleanup"
+msgstr "日志清理"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:32
+msgid "Log Cleanup Cron Expression"
+msgstr "日志清理 Cron 表达式"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:49
+msgid "Log Cleanup Size Threshold (MB)"
+msgstr "日志清理大小阈值（MB）"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:42
+msgid "Log Size Check Cron Expression"
+msgstr "日志大小检查 Cron 表达式"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:37
+msgid "Run unconditional log cleanup at the configured cron schedule."
+msgstr "按设定的 Cron 时间无条件执行日志清理。"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:29
+msgid "Scheduled Log Cleanup"
+msgstr "定时日志清理"
+
+#: applications/luci-app-momo/htdocs/luci-static/resources/view/momo/log.js:39
+msgid "Size-based Log Cleanup"
+msgstr "按大小触发日志清理"

--- a/momo/files/momo.conf
+++ b/momo/files/momo.conf
@@ -8,6 +8,13 @@ config config 'config'
 	option 'test_profile' '1'
 	option 'core_only' '0'
 
+config log 'log'
+	option 'log_cleanup_enabled' '0'
+	option 'log_cleanup_cron_expression' '0 4 * * *'
+	option 'log_cleanup_size_enabled' '0'
+	option 'log_cleanup_size_check_cron_expression' '*/30 * * * *'
+	option 'log_cleanup_size_mb' '50'
+
 config procd 'procd'
 	option 'fast_reload' '0'
 

--- a/momo/files/momo.init
+++ b/momo/files/momo.init
@@ -9,6 +9,8 @@ PROG="/usr/bin/sing-box"
 . "$IPKG_INSTROOT/etc/momo/scripts/include.sh"
 
 extra_command 'update_subscription' 'Update subscription by section id'
+extra_command 'cleanup_logs' 'Cleanup logs immediately'
+extra_command 'check_log_cleanup' 'Cleanup logs if size threshold is reached'
 
 boot_func() {
 	# prepare files
@@ -56,11 +58,17 @@ start_service() {
 	# get config
 	## app config
 	local scheduled_restart cron_expression profile test_profile core_only
+	local log_cleanup_enabled log_cleanup_cron_expression log_cleanup_size_enabled log_cleanup_size_check_cron_expression log_cleanup_size_mb
 	config_get_bool scheduled_restart "config" "scheduled_restart" 0
 	config_get cron_expression "config" "cron_expression"
 	config_get profile "config" "profile"
 	config_get_bool test_profile "config" "test_profile" 0
 	config_get_bool core_only "config" "core_only" 0
+	config_get_bool log_cleanup_enabled "log" "log_cleanup_enabled" 0
+	config_get log_cleanup_cron_expression "log" "log_cleanup_cron_expression"
+	config_get_bool log_cleanup_size_enabled "log" "log_cleanup_size_enabled" 0
+	config_get log_cleanup_size_check_cron_expression "log" "log_cleanup_size_check_cron_expression"
+	config_get log_cleanup_size_mb "log" "log_cleanup_size_mb" 0
 	## procd config
 	### general
 	local fast_reload
@@ -194,9 +202,23 @@ start_service() {
 
 	procd_close_instance
 	# cron
+	local cron_reload; cron_reload=0
 	if [ "$scheduled_restart" = 1 ] && [ -n "$cron_expression" ]; then
 		log "App" "Set scheduled restart."
-		echo "$cron_expression /etc/init.d/momo restart #momo" >> "/etc/crontabs/root"
+		echo "$cron_expression /etc/init.d/momo restart #momo_scheduled_restart" >> "/etc/crontabs/root"
+		cron_reload=1
+	fi
+	if [ "$log_cleanup_enabled" = 1 ] && [ -n "$log_cleanup_cron_expression" ]; then
+		log "Log" "Set scheduled log cleanup."
+		echo "$log_cleanup_cron_expression /etc/init.d/momo cleanup_logs > /dev/null 2>&1 #momo_log_cleanup_time" >> "/etc/crontabs/root"
+		cron_reload=1
+	fi
+	if [ "$log_cleanup_size_enabled" = 1 ] && [ -n "$log_cleanup_size_check_cron_expression" ] && [ "${log_cleanup_size_mb:-0}" -gt 0 ]; then
+		log "Log" "Set size-based log cleanup check."
+		echo "$log_cleanup_size_check_cron_expression /etc/init.d/momo check_log_cleanup > /dev/null 2>&1 #momo_log_cleanup_size" >> "/etc/crontabs/root"
+		cron_reload=1
+	fi
+	if [ "$cron_reload" = 1 ]; then
 		/etc/init.d/cron restart
 	fi
 	# set started flag
@@ -403,6 +425,46 @@ cleanup() {
 	# delete cron
 	sed -i "/#momo/d" "/etc/crontabs/root" > /dev/null 2>&1
 	/etc/init.d/cron restart
+}
+
+cleanup_logs() {
+	prepare_files
+	run_log_cleanup "scheduled trigger"
+}
+
+check_log_cleanup() {
+	prepare_files
+	config_load momo
+
+	local log_cleanup_size_enabled log_cleanup_size_mb total_size_bytes threshold_size_bytes
+	config_get_bool log_cleanup_size_enabled "log" "log_cleanup_size_enabled" 0
+	config_get log_cleanup_size_mb "log" "log_cleanup_size_mb" 0
+
+	if [ "$log_cleanup_size_enabled" != 1 ] || [ "${log_cleanup_size_mb:-0}" -le 0 ]; then
+		return
+	fi
+
+	total_size_bytes=$(get_total_log_size)
+	threshold_size_bytes=$((log_cleanup_size_mb * 1024 * 1024))
+
+	if [ "$total_size_bytes" -lt "$threshold_size_bytes" ]; then
+		return
+	fi
+
+	run_log_cleanup "size threshold ${log_cleanup_size_mb} MB reached" "$total_size_bytes"
+}
+
+run_log_cleanup() {
+	local reason previous_size
+	reason="$1"
+	previous_size="$2"
+
+	if [ -z "$previous_size" ]; then
+		previous_size=$(get_total_log_size)
+	fi
+
+	clear_log
+	log "Log" "Cleanup executed: ${reason}. Previous total size: $(format_filesize "$previous_size")."
 }
 
 update_subscription() {

--- a/momo/files/scripts/include.sh
+++ b/momo/files/scripts/include.sh
@@ -118,6 +118,9 @@ prepare_files() {
 	if [ ! -f "$CORE_LOG_PATH" ]; then
 		touch "$CORE_LOG_PATH"
 	fi
+	if [ ! -f "$DEBUG_LOG_PATH" ]; then
+		touch "$DEBUG_LOG_PATH"
+	fi
 	if [ ! -d "$TEMP_DIR" ]; then
 		mkdir -p "$TEMP_DIR"
 	fi
@@ -126,6 +129,26 @@ prepare_files() {
 clear_log() {
 	echo -n > "$APP_LOG_PATH"
 	echo -n > "$CORE_LOG_PATH"
+	echo -n > "$DEBUG_LOG_PATH"
+}
+
+get_filesize() {
+	local path; path="$1"
+	if [ ! -f "$path" ]; then
+		echo 0
+		return
+	fi
+	wc -c < "$path" | tr -d '[:space:]'
+}
+
+get_total_log_size() {
+	local total_size path path_size
+	total_size=0
+	for path in "$APP_LOG_PATH" "$CORE_LOG_PATH" "$DEBUG_LOG_PATH"; do
+		path_size=$(get_filesize "$path")
+		total_size=$((total_size + path_size))
+	done
+	echo "$total_size"
 }
 
 log() {

--- a/momo/files/uci-defaults/migrate.sh
+++ b/momo/files/uci-defaults/migrate.sh
@@ -25,6 +25,45 @@ procd=$(uci -q get momo.procd); [ -z "$procd" ] && {
 
 dummy_device=$(uci -q get momo.routing.dummy_device); [ -z "$dummy_device" ] && uci set momo.routing.dummy_device=momo-dummy
 
+# since v1.1.2
+
+section_log=$(uci -q get momo.log); [ -z "$section_log" ] && uci set momo.log=log
+
+log_cleanup_enabled=$(uci -q get momo.log.log_cleanup_enabled)
+[ -z "$log_cleanup_enabled" ] && {
+	log_cleanup_enabled=$(uci -q get momo.config.log_cleanup_enabled)
+	[ -n "$log_cleanup_enabled" ] && uci set momo.log.log_cleanup_enabled=$log_cleanup_enabled || uci set momo.log.log_cleanup_enabled=0
+}
+uci -q del momo.config.log_cleanup_enabled
+
+log_cleanup_cron_expression=$(uci -q get momo.log.log_cleanup_cron_expression)
+[ -z "$log_cleanup_cron_expression" ] && {
+	log_cleanup_cron_expression=$(uci -q get momo.config.log_cleanup_cron_expression)
+	[ -n "$log_cleanup_cron_expression" ] && uci set momo.log.log_cleanup_cron_expression="$log_cleanup_cron_expression" || uci set momo.log.log_cleanup_cron_expression='0 4 * * *'
+}
+uci -q del momo.config.log_cleanup_cron_expression
+
+log_cleanup_size_enabled=$(uci -q get momo.log.log_cleanup_size_enabled)
+[ -z "$log_cleanup_size_enabled" ] && {
+	log_cleanup_size_enabled=$(uci -q get momo.config.log_cleanup_size_enabled)
+	[ -n "$log_cleanup_size_enabled" ] && uci set momo.log.log_cleanup_size_enabled=$log_cleanup_size_enabled || uci set momo.log.log_cleanup_size_enabled=0
+}
+uci -q del momo.config.log_cleanup_size_enabled
+
+log_cleanup_size_check_cron_expression=$(uci -q get momo.log.log_cleanup_size_check_cron_expression)
+[ -z "$log_cleanup_size_check_cron_expression" ] && {
+	log_cleanup_size_check_cron_expression=$(uci -q get momo.config.log_cleanup_size_check_cron_expression)
+	[ -n "$log_cleanup_size_check_cron_expression" ] && uci set momo.log.log_cleanup_size_check_cron_expression="$log_cleanup_size_check_cron_expression" || uci set momo.log.log_cleanup_size_check_cron_expression='*/30 * * * *'
+}
+uci -q del momo.config.log_cleanup_size_check_cron_expression
+
+log_cleanup_size_mb=$(uci -q get momo.log.log_cleanup_size_mb)
+[ -z "$log_cleanup_size_mb" ] && {
+	log_cleanup_size_mb=$(uci -q get momo.config.log_cleanup_size_mb)
+	[ -n "$log_cleanup_size_mb" ] && uci set momo.log.log_cleanup_size_mb=$log_cleanup_size_mb || uci set momo.log.log_cleanup_size_mb=50
+}
+uci -q del momo.config.log_cleanup_size_mb
+
 # commit
 uci commit momo
 


### PR DESCRIPTION
## Summary
- add configurable scheduled log cleanup options in UCI and LuCI
- support cleanup triggers by cron schedule and combined log size threshold
- wire migration defaults and init cron commands for app/core/debug logs

## Testing
- git diff --check
- sh -n momo/files/momo.init\n- sh -n momo/files/scripts/include.sh
- sh -n momo/files/uci-defaults/migrate.sh
- node --check luci-app-momo/htdocs/luci-static/resources/view/momo/app.js